### PR TITLE
Change title of 'Flaches Rendern' back to 'Shallow Renderer'

### DIFF
--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -1,6 +1,6 @@
 ---
 id: shallow-renderer
-title: Flaches Rendern
+title: Shallow Renderer
 permalink: docs/shallow-renderer.html
 layout: docs
 category: Reference

--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -1,68 +1,67 @@
 ---
 id: shallow-renderer
-title: Shallow Renderer
+title: Flaches Rendern
 permalink: docs/shallow-renderer.html
 layout: docs
 category: Reference
 ---
 
-**Importing**
+**Import**
 
 ```javascript
 import ShallowRenderer from 'react-test-renderer/shallow'; // ES6
-var ShallowRenderer = require('react-test-renderer/shallow'); // ES5 with npm
+var ShallowRenderer = require('react-test-renderer/shallow'); // ES5 mit npm
 ```
 
-## Overview {#overview}
+## Übersicht {#overview}
 
-When writing unit tests for React, shallow rendering can be helpful. Shallow rendering lets you render a component "one level deep" and assert facts about what its render method returns, without worrying about the behavior of child components, which are not instantiated or rendered. This does not require a DOM.
+Beim Schreiben von *unit tests* kann flaches Rendering (engl. shallow rendering) hilfreich sein. Flaches Rendering ermöglicht es, eine Komponente "einen Level tief" zu rendern, und vergleicht den zurückgegebenen Wert der Render Methode, ohne über das Verhalten der Kinder-Komponenten, welche beim flachen Rendering nicht instanziiert oder gerendert werden. Dies verlangt nicht einen DOM.
 
-For example, if you have the following component:
+Wenn du zum Beispiel folgendes Komponent hast:
 
 ```javascript
 function MyComponent() {
   return (
     <div>
-      <span className="heading">Title</span>
+      <span className="heading">Titel</span>
       <Subcomponent foo="bar" />
     </div>
   );
 }
 ```
-
-Then you can assert:
+So können wir sie testen:
 
 ```javascript
 import ShallowRenderer from 'react-test-renderer/shallow';
 
-// in your test:
+// in deinem Test:
 const renderer = new ShallowRenderer();
 renderer.render(<MyComponent />);
 const result = renderer.getRenderOutput();
 
 expect(result.type).toBe('div');
 expect(result.props.children).toEqual([
-  <span className="heading">Title</span>,
+  <span className="heading">Titel</span>,
   <Subcomponent foo="bar" />
 ]);
 ```
 
-Shallow testing currently has some limitations, namely not supporting refs.
+Zurzeit hat flaches Rendering die Einschränkung, dass `refs` nicht unterstützt werden.
 
-> Note:
+> Hinweis:
 >
-> We also recommend checking out Enzyme's [Shallow Rendering API](https://airbnb.io/enzyme/docs/api/shallow.html). It provides a nicer higher-level API over the same functionality.
+> Wir empfehlen, sich die [Shallow Rendering API](https://airbnb.io/enzyme/docs/api/shallow.html) von Enzyme anzusehen. Sie ermöglicht eine bessere *high-level API* mit denselben Funktionalitäten.
 
-## Reference {#reference}
+## Referenz {#reference}
 
 ### `shallowRenderer.render()` {#shallowrendererrender}
 
-You can think of the shallowRenderer as a "place" to render the component you're testing, and from which you can extract the component's output.
+Man kann sich shallowRenderer als den "Ort" vorstellen, in der man die Komponente testet, und von wo aus der Output der Komponente entnommen wird.
 
-`shallowRenderer.render()` is similar to [`ReactDOM.render()`](/docs/react-dom.html#render) but it doesn't require DOM and only renders a single level deep. This means you can test components isolated from how their children are implemented.
+`shallowRenderer.render()` ist ähnlich wie [`ReactDOM.render()`](/docs/react-dom.html#render), nur dass es keinen DOM benötigt und nur einen Level tief rendert. Das bedeutet, dass man Komponenten isoliert von der Art und Weise wie deren Kinder-Komponenten implementiert werden, testen kann.
 
 ### `shallowRenderer.getRenderOutput()` {#shallowrenderergetrenderoutput}
 
-After `shallowRenderer.render()` has been called, you can use `shallowRenderer.getRenderOutput()` to get the shallowly rendered output.
+Nachdem `shallowRenderer.render()` aufgerufen worden ist, bekommt man mit `shallowRenderer.getRenderOutput()` den flachen gerenderten Output.
 
-You can then begin to assert facts about the output.
+Dann kann man anfangen, den Output zu testen.

--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -15,7 +15,7 @@ var ShallowRenderer = require('react-test-renderer/shallow'); // ES5 mit npm
 
 ## Übersicht {#overview}
 
-Beim Schreiben von *unit tests* kann flaches Rendering (engl. shallow rendering) hilfreich sein. Flaches Rendering ermöglicht es, eine Komponente "einen Level tief" zu rendern, und vergleicht den zurückgegebenen Wert der Render Methode, ohne über das Verhalten der Kinder-Komponenten, welche beim flachen Rendering nicht instanziiert oder gerendert werden. Dies verlangt nicht einen DOM.
+Beim Schreiben von *unit tests* kann flaches Rendering (engl. shallow rendering) hilfreich sein. Flaches Rendering ermöglicht es, eine Komponente "einen Level tief" zu rendern, und vergleicht den zurückgegebenen Wert der Render Methode, ohne sich über das Verhalten der Kind-Komponenten, welche nicht instanziiert oder gerendert werden, Sorgen zu machen. Ein DOM wird hierbei nicht verlangt.
 
 Wenn du zum Beispiel folgendes Komponent hast:
 

--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -56,7 +56,7 @@ Zurzeit hat flaches Rendering die Einschränkung, dass `refs` nicht unterstützt
 
 ### `shallowRenderer.render()` {#shallowrendererrender}
 
-Man kann sich shallowRenderer als den "Ort" vorstellen, in der man die Komponente testet, und von wo aus der Output der Komponente entnommen wird.
+Du kannst dir den shallowRenderer als den "Ort" vorstellen an dem die zu testende Komponente gerendert wird, und du daraus die Ausgabe der Komponente entnehmen kannst.
 
 `shallowRenderer.render()` ist ähnlich wie [`ReactDOM.render()`](/docs/react-dom.html#render), nur dass es keinen DOM benötigt und nur einen Level tief rendert. Das bedeutet, dass man Komponenten isoliert von der Art und Weise wie deren Kinder-Komponenten implementiert werden, testen kann.
 

--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -17,7 +17,7 @@ var ShallowRenderer = require('react-test-renderer/shallow'); // ES5 mit npm
 
 Beim Schreiben von *unit tests* kann flaches Rendering (engl. shallow rendering) hilfreich sein. Flaches Rendering ermöglicht es, eine Komponente "einen Level tief" zu rendern, und vergleicht den zurückgegebenen Wert der Render Methode, ohne sich über das Verhalten der Kind-Komponenten, welche nicht instanziiert oder gerendert werden, Sorgen zu machen. Ein DOM wird hierbei nicht verlangt.
 
-Wenn du zum Beispiel folgendes Komponent hast:
+Wenn du zum Beispiel folgende Komponente hast:
 
 ```javascript
 function MyComponent() {

--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -58,7 +58,7 @@ Zurzeit hat flaches Rendering die Einschränkung, dass `refs` nicht unterstützt
 
 Du kannst dir den shallowRenderer als den "Ort" vorstellen an dem die zu testende Komponente gerendert wird, und du daraus die Ausgabe der Komponente entnehmen kannst.
 
-`shallowRenderer.render()` ist ähnlich wie [`ReactDOM.render()`](/docs/react-dom.html#render), nur dass es keinen DOM benötigt und nur einen Level tief rendert. Das bedeutet, dass man Komponenten isoliert von der Art und Weise wie deren Kinder-Komponenten implementiert werden, testen kann.
+`shallowRenderer.render()` ist ähnlich wie [`ReactDOM.render()`](/docs/react-dom.html#render), nur dass es kein DOM benötigt und nur einen Level tief rendert. Das bedeutet, dass du Komponenten abgegrenzt testen kannst, unabhängig davon wie die Kind-Komponenten implementiert sind.
 
 ### `shallowRenderer.getRenderOutput()` {#shallowrenderergetrenderoutput}
 

--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -46,11 +46,12 @@ expect(result.props.children).toEqual([
 ]);
 ```
 
-Zurzeit hat flaches Rendering die Einschränkung, dass `refs` nicht unterstützt werden.
+Flaches Rendering hat derzeit die Einschränkung, dass refs nicht unterstützt werden.
 
 > Hinweis:
 >
-> Wir empfehlen, sich die [Shallow Rendering API](https://airbnb.io/enzyme/docs/api/shallow.html) von Enzyme anzusehen. Sie ermöglicht eine bessere *high-level API* mit denselben Funktionalitäten.
+> Wir empfehlen auch, sich die [Shallow Rendering API](https://airbnb.io/enzyme/docs/api/shallow.html) von Enzyme anzusehen. Sie stellt eine angenehmere *übergeordnete API* mit den gleichen Funktionalitäten bereit.
+
 
 ## Referenz {#reference}
 
@@ -64,4 +65,4 @@ Du kannst dir den shallowRenderer als den "Ort" vorstellen an dem die zu testend
 
 Nachdem `shallowRenderer.render()` aufgerufen wurde, kannst du dir mit `shallowRenderer.getRenderOutput()` die flach gerenderte Ausgabe zurückgeben lassen.
 
-Dann kann man anfangen, den Output zu testen.
+Dann kann man anfangen, die Ausgabe zu testen.

--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -62,6 +62,6 @@ Du kannst dir den shallowRenderer als den "Ort" vorstellen an dem die zu testend
 
 ### `shallowRenderer.getRenderOutput()` {#shallowrenderergetrenderoutput}
 
-Nachdem `shallowRenderer.render()` aufgerufen worden ist, bekommt man mit `shallowRenderer.getRenderOutput()` den flachen gerenderten Output.
+Nachdem `shallowRenderer.render()` aufgerufen wurde, kannst du dir mit `shallowRenderer.getRenderOutput()` die flach gerenderte Ausgabe zurückgeben lassen.
 
 Dann kann man anfangen, den Output zu testen.

--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -97,7 +97,7 @@
     - id: test-utils
       title: Test Utilities
     - id: shallow-renderer
-      title: Flaches Rendern
+      title: Shallow Renderer
     - id: test-renderer
       title: Test Renderer
     - id: javascript-environment-requirements

--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -97,7 +97,7 @@
     - id: test-utils
       title: Test Utilities
     - id: shallow-renderer
-      title: Shallow Renderer
+      title: Flaches Rendern
     - id: test-renderer
       title: Test Renderer
     - id: javascript-environment-requirements


### PR DESCRIPTION
Hi,

I want to change the title of the page 'Flaches Rendern' back to how it was -> 'Shallow Renderer'.

My reason: as this chapter is part of the API references, The actual package which is getting imported is shallowRenderer and if somebody is going through the nav looking for help for this specific package, I doubt  they would find it if the title is 'flaches Rendern'.  I would leave the rest of the page as it is.

I've also just translate the page after 'shallow renderer', 'test renderer' and it makes more sense to leave the headings as they are for those two instances. 

Please discuss! :) 

Edit: Sorry I didn't update my fork's master before creating the PR so all the previous commits are in it as well! 